### PR TITLE
build(deps): bump log4j2 from 2.19.0 to 2.20.0

### DIFF
--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,5 +1,5 @@
 extra["slf4j_version"] = "2.0.6"
 extra["coroutines_version"] = "1.6.4"
-extra["log4j_version"] = "2.19.0"
+extra["log4j_version"] = "2.20.0"
 extra["mockito_version"] = "4.8.0"
 extra["junit_version"] = "5.9.1"


### PR DESCRIPTION
Release notes https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html