### PR TITLE
build(deps): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
See https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

This should reduce the manual work needed to create pull requests such as https://github.com/oshai/kotlin-logging/pull/287