### PR TITLE
Allow turning off logging with `Level.OFF`

### DIFF
--- a/src/androidMain/kotlin/io/github/oshai/KLogger.kt
+++ b/src/androidMain/kotlin/io/github/oshai/KLogger.kt
@@ -118,4 +118,11 @@ public actual interface KLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   public actual val isErrorEnabled: Boolean
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  public actual val isLoggingOff: Boolean
 }

--- a/src/androidMain/kotlin/io/github/oshai/internal/KLoggerAndroid.kt
+++ b/src/androidMain/kotlin/io/github/oshai/internal/KLoggerAndroid.kt
@@ -130,4 +130,11 @@ internal class KLoggerAndroid(override val name: String) : KLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   override val isErrorEnabled: Boolean = Log.isLoggable(name, Log.ERROR)
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  override val isLoggingOff: Boolean = !Log.isLoggable(name, Log.ASSERT)
 }

--- a/src/commonMain/kotlin/io/github/oshai/KLogger.kt
+++ b/src/commonMain/kotlin/io/github/oshai/KLogger.kt
@@ -138,6 +138,7 @@ public fun KLogger.isEnabledForLevel(level: Level): Boolean {
     Levels.INFO_INT -> isInfoEnabled
     Levels.WARN_INT -> isWarnEnabled
     Levels.ERROR_INT -> isErrorEnabled
+    Levels.OFF_INT -> false
     else -> throw IllegalArgumentException("Level [$level] not recognized.")
   }
 }

--- a/src/commonMain/kotlin/io/github/oshai/KLogger.kt
+++ b/src/commonMain/kotlin/io/github/oshai/KLogger.kt
@@ -123,6 +123,13 @@ public expect interface KLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   public val isErrorEnabled: Boolean
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  public val isLoggingOff: Boolean
 }
 
 /**
@@ -138,7 +145,7 @@ public fun KLogger.isEnabledForLevel(level: Level): Boolean {
     Levels.INFO_INT -> isInfoEnabled
     Levels.WARN_INT -> isWarnEnabled
     Levels.ERROR_INT -> isErrorEnabled
-    Levels.OFF_INT -> false
+    Levels.OFF_INT -> isLoggingOff
     else -> throw IllegalArgumentException("Level [$level] not recognized.")
   }
 }
@@ -261,4 +268,11 @@ public interface ActualKLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   public val isErrorEnabled: Boolean
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  public val isLoggingOff: Boolean
 }

--- a/src/commonMain/kotlin/io/github/oshai/Level.kt
+++ b/src/commonMain/kotlin/io/github/oshai/Level.kt
@@ -6,6 +6,7 @@ public enum class Level(private val levelInt: Int, private val levelStr: String)
   INFO(Levels.INFO_INT, "INFO"),
   WARN(Levels.WARN_INT, "WARN"),
   ERROR(Levels.ERROR_INT, "ERROR"),
+  OFF(Levels.OFF_INT, "OFF"),
   ;
 
   public fun toInt(): Int {
@@ -25,6 +26,7 @@ public object Levels {
   public const val INFO_INT: Int = 20
   public const val WARN_INT: Int = 30
   public const val ERROR_INT: Int = 40
+  public const val OFF_INT: Int = 50
 
   public fun intToLevel(levelInt: Int): Level {
     return when (levelInt) {
@@ -33,6 +35,7 @@ public object Levels {
       INFO_INT -> Level.INFO
       WARN_INT -> Level.WARN
       ERROR_INT -> Level.ERROR
+      OFF_INT -> Level.OFF
       else -> throw IllegalArgumentException("Level integer [$levelInt] not recognized.")
     }
   }

--- a/src/jsMain/kotlin/io/github/oshai/internal/KLoggerJS.kt
+++ b/src/jsMain/kotlin/io/github/oshai/internal/KLoggerJS.kt
@@ -7,6 +7,7 @@ import io.github.oshai.Level
 import io.github.oshai.Level.DEBUG
 import io.github.oshai.Level.ERROR
 import io.github.oshai.Level.INFO
+import io.github.oshai.Level.OFF
 import io.github.oshai.Level.TRACE
 import io.github.oshai.Level.WARN
 import io.github.oshai.Marker
@@ -166,4 +167,11 @@ internal class KLoggerJS(override val name: String) : KLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   override val isErrorEnabled: Boolean = ERROR.isLoggingEnabled()
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  override val isLoggingOff: Boolean = OFF.isLoggingEnabled()
 }

--- a/src/jsTest/kotlin/io/github/oshai/SimpleJsTest.kt
+++ b/src/jsTest/kotlin/io/github/oshai/SimpleJsTest.kt
@@ -1,21 +1,41 @@
 package io.github.oshai
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 private val logger = KotlinLogging.logger("SimpleJsTest")
 
 class SimpleJsTest {
+  private lateinit var appender: SimpleAppender
+
+  @BeforeTest
+  fun setup() {
+    appender = createAppender()
+    KotlinLoggingConfiguration.APPENDER = appender
+  }
+
+  @AfterTest
+  fun cleanup() {
+    KotlinLoggingConfiguration.APPENDER = ConsoleOutputAppender
+    KotlinLoggingConfiguration.LOG_LEVEL = Level.INFO
+  }
 
   @Test
   fun simpleJsTest() {
-    val appender = createAppender()
-    KotlinLoggingConfiguration.APPENDER = appender
     assertEquals("SimpleJsTest", logger.name)
     logger.info { "info msg" }
     assertEquals("INFO: [SimpleJsTest] info msg", appender.lastMessage)
     assertEquals("info", appender.lastLevel)
-    KotlinLoggingConfiguration.APPENDER = ConsoleOutputAppender
+  }
+
+  @Test
+  fun offLevelJsTest() {
+    KotlinLoggingConfiguration.LOG_LEVEL = Level.OFF
+    logger.error { "error msg" }
+    assertEquals("NA", appender.lastMessage)
+    assertEquals("NA", appender.lastLevel)
   }
 
   @Test

--- a/src/jsTest/kotlin/io/github/oshai/SimpleJsTest.kt
+++ b/src/jsTest/kotlin/io/github/oshai/SimpleJsTest.kt
@@ -1,9 +1,6 @@
 package io.github.oshai
 
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 private val logger = KotlinLogging.logger("SimpleJsTest")
 
@@ -33,6 +30,7 @@ class SimpleJsTest {
   @Test
   fun offLevelJsTest() {
     KotlinLoggingConfiguration.LOG_LEVEL = Level.OFF
+    assertTrue(logger.isLoggingOff)
     logger.error { "error msg" }
     assertEquals("NA", appender.lastMessage)
     assertEquals("NA", appender.lastLevel)

--- a/src/jvmMain/kotlin/io/github/oshai/KLogger.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/KLogger.kt
@@ -549,4 +549,12 @@ public actual interface KLogger : ActualKLogger {
    * @param t the exception (throwable) to log
    */
   public fun error(marker: Marker?, msg: String?, t: Throwable?)
+
+  /**
+   * Similar to [.isLoggingOff] method except that the marker data is also taken into consideration.
+   *
+   * @param marker The marker data to take into consideration
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  public fun isLoggingOff(marker: Marker?): Boolean
 }

--- a/src/jvmMain/kotlin/io/github/oshai/jul/internal/JulLoggerWrapper.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/jul/internal/JulLoggerWrapper.kt
@@ -387,6 +387,7 @@ internal class JulLoggerWrapper(override val underlyingLogger: Logger) : KLogger
         INFO -> Level.INFO
         WARN -> Level.WARNING
         ERROR -> Level.SEVERE
+        OFF -> Level.OFF
       }
     return julLevel
   }

--- a/src/jvmMain/kotlin/io/github/oshai/jul/internal/JulLoggerWrapper.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/jul/internal/JulLoggerWrapper.kt
@@ -379,6 +379,13 @@ internal class JulLoggerWrapper(override val underlyingLogger: Logger) : KLogger
     return underlyingLogger.isLoggable(ERROR.toJULLevel())
   }
 
+  override val isLoggingOff: Boolean
+    get() = underlyingLogger.isLoggable(OFF.toJULLevel())
+
+  override fun isLoggingOff(marker: Marker?): Boolean {
+    return underlyingLogger.isLoggable(OFF.toJULLevel())
+  }
+
   private fun io.github.oshai.Level.toJULLevel(): Level {
     val julLevel: Level =
       when (this) {

--- a/src/jvmMain/kotlin/io/github/oshai/slf4j/internal/Slf4jLoggerWrapper.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/slf4j/internal/Slf4jLoggerWrapper.kt
@@ -44,4 +44,11 @@ internal abstract class Slf4jLoggerWrapper(override val underlyingLogger: Logger
   override fun isErrorEnabled(marker: Marker?): Boolean {
     return underlyingLogger.isErrorEnabled(marker?.toSlf4j())
   }
+
+  override val isLoggingOff: Boolean
+    get() = !underlyingLogger.isErrorEnabled
+
+  override fun isLoggingOff(marker: Marker?): Boolean {
+    return !underlyingLogger.isErrorEnabled(marker?.toSlf4j())
+  }
 }

--- a/src/nativeMain/kotlin/io/github/oshai/internal/KLoggerNative.kt
+++ b/src/nativeMain/kotlin/io/github/oshai/internal/KLoggerNative.kt
@@ -177,4 +177,11 @@ internal class KLoggerNative(override val name: String) : KLogger {
    * @return True if this Logger is enabled for the ERROR level, false otherwise.
    */
   override val isErrorEnabled: Boolean = ERROR.isLoggingEnabled()
+
+  /**
+   * Is the logger instance OFF?
+   *
+   * @return True if this Logger is set to the OFF level, false otherwise.
+   */
+  override val isLoggingOff: Boolean = OFF.isLoggingEnabled()
 }

--- a/src/nativeTest/kotlin/io/github/oshai/SimpleNativeTest.kt
+++ b/src/nativeTest/kotlin/io/github/oshai/SimpleNativeTest.kt
@@ -1,9 +1,6 @@
 package io.github.oshai
 
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 private val logger = KotlinLogging.logger {}
 
@@ -34,6 +31,7 @@ class SimpleNativeTest {
   @Test
   fun offLevelNativeTest() {
     KotlinLoggingConfiguration.logLevel = Level.OFF
+    assertTrue(logger.isLoggingOff)
     logger.error { "error msg" }
     assertEquals("NA", appender.lastMessage)
     assertEquals("NA", appender.lastLevel)

--- a/src/nativeTest/kotlin/io/github/oshai/SimpleNativeTest.kt
+++ b/src/nativeTest/kotlin/io/github/oshai/SimpleNativeTest.kt
@@ -1,22 +1,43 @@
 package io.github.oshai
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 private val logger = KotlinLogging.logger {}
 
 class SimpleNativeTest {
+  private lateinit var appender: SimpleAppender
+
+  @BeforeTest
+  fun setup() {
+    appender = createAppender()
+    KotlinLoggingConfiguration.appender = appender
+  }
+
+  @AfterTest
+  fun cleanup() {
+    KotlinLoggingConfiguration.appender = ConsoleOutputAppender
+    KotlinLoggingConfiguration.logLevel = Level.INFO
+  }
 
   @Test
   fun simpleNativeTest() {
-    val appender = createAppender()
-    KotlinLoggingConfiguration.appender = appender
     assertEquals("SimpleNativeTest", logger.name)
     logger.info { "info msg" }
     assertEquals("INFO: [SimpleNativeTest] info msg", appender.lastMessage)
     assertEquals("info", appender.lastLevel)
     assertEquals("info", appender.lastLoggerName)
-    KotlinLoggingConfiguration.appender = ConsoleOutputAppender
+  }
+
+  @Test
+  fun offLevelNativeTest() {
+    KotlinLoggingConfiguration.logLevel = Level.OFF
+    logger.error { "error msg" }
+    assertEquals("NA", appender.lastMessage)
+    assertEquals("NA", appender.lastLevel)
+    assertEquals("NA", appender.lastLoggerName)
   }
 
   private fun createAppender(): SimpleAppender = SimpleAppender()


### PR DESCRIPTION
Fixes #310.

I added the minimum amount of code to make this work, together with a test for JS and native.

It might make sense to add an `isOff` property to `KLogger` (which could probably even be implemented in common code as `!isErrorEnabled`), let me know what you think.