### PR TITLE
Append entries of payload to LoggingEventBuilder

### DIFF
--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
@@ -24,6 +24,7 @@ internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) :
       KLoggingEventBuilder().apply(block).run {
         val builder = underlyingLogger.atLevel(level.toSlf4j())
         marker?.toSlf4j()?.let { builder.addMarker(it) }
+        payload?.forEach { (key, value) -> builder.addKeyValue(key, value) }
         builder.setCause(cause)
         builder.log(message)
       }


### PR DESCRIPTION
payload entries should be added to slf4j builder so implementations like logback can make use of this data