### PR TITLE
Split cases to with / without payload.

### DIFF
--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/Slf4jExtensions.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/Slf4jExtensions.kt
@@ -20,17 +20,6 @@ public fun Level.toSlf4j(): org.slf4j.event.Level =
     Level.OFF -> throw IllegalArgumentException("OFF level is not supported")
   }
 
-public fun Logger.isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
-  return when (level) {
-    Level.TRACE -> this.isTraceEnabled(marker?.toSlf4j())
-    Level.DEBUG -> this.isDebugEnabled(marker?.toSlf4j())
-    Level.INFO -> this.isInfoEnabled(marker?.toSlf4j())
-    Level.WARN -> this.isWarnEnabled(marker?.toSlf4j())
-    Level.ERROR -> this.isErrorEnabled(marker?.toSlf4j())
-    Level.OFF -> false
-  }
-}
-
 @Suppress("UnusedReceiverParameter")
 public fun KotlinLogging.logger(underlyingLogger: Logger): KLogger =
   Slf4jLoggerFactory.wrapJLogger(underlyingLogger)

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationAwareKLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationAwareKLogger.kt
@@ -22,7 +22,7 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
   override val name: String
     get() = underlyingLogger.name
 
-  private val fqcn: String? = LocationAwareKLogger::class.java.name
+  private val fqcn: String = LocationAwareKLogger::class.java.name
 
   private val ENTRY = io.github.oshai.kotlinlogging.KMarkerFactory.getMarker("ENTRY").toSlf4j()
   private val EXIT = io.github.oshai.kotlinlogging.KMarkerFactory.getMarker("EXIT").toSlf4j()

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
@@ -5,7 +5,6 @@ import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KLoggingEventBuilder
 import io.github.oshai.kotlinlogging.Level
 import io.github.oshai.kotlinlogging.Marker
-import io.github.oshai.kotlinlogging.slf4j.isLoggingEnabledFor
 import io.github.oshai.kotlinlogging.slf4j.toSlf4j
 import org.slf4j.Logger
 
@@ -15,23 +14,48 @@ import org.slf4j.Logger
  * methods
  */
 internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) :
-  KLogger, DelegatingKLogger<Logger>, Slf4jLogger() {
-  override val name: String
-    get() = underlyingLogger.name
+  KLogger, DelegatingKLogger<Logger>, Slf4jLogger<Logger>() {
 
-  override fun at(level: Level, marker: Marker?, block: KLoggingEventBuilder.() -> Unit) {
-    if (isLoggingEnabledFor(level, marker)) {
-      KLoggingEventBuilder().apply(block).run {
-        val builder = underlyingLogger.atLevel(level.toSlf4j())
-        marker?.toSlf4j()?.let { builder.addMarker(it) }
-        payload?.forEach { (key, value) -> builder.addKeyValue(key, value) }
-        builder.setCause(cause)
-        builder.log(message)
-      }
+  override val fqcn: String?
+    get() = null
+
+  override fun logWithoutPayload(
+    kLoggingEventBuilder: KLoggingEventBuilder,
+    level: Level,
+    marker: Marker?
+  ) {
+    when (level) {
+      Level.TRACE ->
+        underlyingLogger.trace(
+          marker?.toSlf4j(),
+          kLoggingEventBuilder.message,
+          kLoggingEventBuilder.cause
+        )
+      Level.DEBUG ->
+        underlyingLogger.debug(
+          marker?.toSlf4j(),
+          kLoggingEventBuilder.message,
+          kLoggingEventBuilder.cause
+        )
+      Level.INFO ->
+        underlyingLogger.info(
+          marker?.toSlf4j(),
+          kLoggingEventBuilder.message,
+          kLoggingEventBuilder.cause
+        )
+      Level.WARN ->
+        underlyingLogger.warn(
+          marker?.toSlf4j(),
+          kLoggingEventBuilder.message,
+          kLoggingEventBuilder.cause
+        )
+      Level.ERROR ->
+        underlyingLogger.error(
+          marker?.toSlf4j(),
+          kLoggingEventBuilder.message,
+          kLoggingEventBuilder.cause
+        )
+      Level.OFF -> Unit
     }
-  }
-
-  override fun isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
-    return underlyingLogger.isLoggingEnabledFor(level, marker)
   }
 }

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
@@ -14,12 +14,40 @@ import org.slf4j.Logger
  * methods
  */
 internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) :
-  KLogger, DelegatingKLogger<Logger>, Slf4jLogger<Logger>() {
+  KLogger, DelegatingKLogger<Logger>, Slf4jLogger() {
 
-  override val fqcn: String?
-    get() = null
+  override val name: String
+    get() = underlyingLogger.name
 
-  override fun logWithoutPayload(
+  override fun isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
+    return isLoggingEnabledFor(underlyingLogger, level, marker)
+  }
+
+  override fun at(level: Level, marker: Marker?, block: KLoggingEventBuilder.() -> Unit) {
+    if (isLoggingEnabledFor(level, marker)) {
+      KLoggingEventBuilder().apply(block).run {
+        if (payload != null) {
+          logWithPayload(this, level, marker)
+        } else {
+          logWithoutPayload(this, level, marker)
+        }
+      }
+    }
+  }
+
+  private fun logWithPayload(
+    kLoggingEventBuilder: KLoggingEventBuilder,
+    level: Level,
+    marker: Marker?
+  ) {
+    val builder = underlyingLogger.atLevel(level.toSlf4j())
+    marker?.toSlf4j()?.let { builder.addMarker(it) }
+    kLoggingEventBuilder.payload?.forEach { (key, value) -> builder.addKeyValue(key, value) }
+    builder.setCause(kLoggingEventBuilder.cause)
+    builder.log(kLoggingEventBuilder.message)
+  }
+
+  private fun logWithoutPayload(
     kLoggingEventBuilder: KLoggingEventBuilder,
     level: Level,
     marker: Marker?

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/LocationIgnorantKLogger.kt
@@ -52,37 +52,15 @@ internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) :
     level: Level,
     marker: Marker?
   ) {
+    val slf4jMarker = marker?.toSlf4j()
+    val message = kLoggingEventBuilder.message
+    val cause = kLoggingEventBuilder.cause
     when (level) {
-      Level.TRACE ->
-        underlyingLogger.trace(
-          marker?.toSlf4j(),
-          kLoggingEventBuilder.message,
-          kLoggingEventBuilder.cause
-        )
-      Level.DEBUG ->
-        underlyingLogger.debug(
-          marker?.toSlf4j(),
-          kLoggingEventBuilder.message,
-          kLoggingEventBuilder.cause
-        )
-      Level.INFO ->
-        underlyingLogger.info(
-          marker?.toSlf4j(),
-          kLoggingEventBuilder.message,
-          kLoggingEventBuilder.cause
-        )
-      Level.WARN ->
-        underlyingLogger.warn(
-          marker?.toSlf4j(),
-          kLoggingEventBuilder.message,
-          kLoggingEventBuilder.cause
-        )
-      Level.ERROR ->
-        underlyingLogger.error(
-          marker?.toSlf4j(),
-          kLoggingEventBuilder.message,
-          kLoggingEventBuilder.cause
-        )
+      Level.TRACE -> underlyingLogger.trace(slf4jMarker, message, cause)
+      Level.DEBUG -> underlyingLogger.debug(slf4jMarker, message, cause)
+      Level.INFO -> underlyingLogger.info(slf4jMarker, message, cause)
+      Level.WARN -> underlyingLogger.warn(slf4jMarker, message, cause)
+      Level.ERROR -> underlyingLogger.error(slf4jMarker, message, cause)
       Level.OFF -> Unit
     }
   }

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
@@ -1,5 +1,61 @@
 package io.github.oshai.kotlinlogging.slf4j.internal
 
+import io.github.oshai.kotlinlogging.DelegatingKLogger
 import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KLoggingEventBuilder
+import io.github.oshai.kotlinlogging.Level
+import io.github.oshai.kotlinlogging.Marker
+import io.github.oshai.kotlinlogging.slf4j.toSlf4j
+import org.slf4j.Logger
+import org.slf4j.spi.CallerBoundaryAware
 
-public abstract class Slf4jLogger : KLogger {}
+public abstract class Slf4jLogger<T : Logger> : KLogger, DelegatingKLogger<T> {
+
+  override val name: String
+    get() = underlyingLogger.name
+
+  protected abstract val fqcn: String?
+  override fun at(level: Level, marker: Marker?, block: KLoggingEventBuilder.() -> Unit) {
+    if (isLoggingEnabledFor(level, marker)) {
+      KLoggingEventBuilder().apply(block).run {
+        if (payload != null) {
+          logWithPayload(this, level, marker)
+        } else {
+          logWithoutPayload(this, level, marker)
+        }
+      }
+    }
+  }
+
+  protected abstract fun logWithoutPayload(
+    kLoggingEventBuilder: KLoggingEventBuilder,
+    level: Level,
+    marker: Marker?
+  )
+
+  private fun logWithPayload(
+    kLoggingEventBuilder: KLoggingEventBuilder,
+    level: Level,
+    marker: Marker?
+  ) {
+    val builder = underlyingLogger.atLevel(level.toSlf4j())
+    marker?.toSlf4j()?.let { builder.addMarker(it) }
+    kLoggingEventBuilder.payload?.forEach { (key, value) -> builder.addKeyValue(key, value) }
+    builder.setCause(kLoggingEventBuilder.cause)
+    if (builder is CallerBoundaryAware) {
+      builder.setCallerBoundary(fqcn)
+    }
+    builder.log(kLoggingEventBuilder.message)
+  }
+
+  override fun isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
+    return when (level) {
+      Level.TRACE -> underlyingLogger.isTraceEnabled(marker?.toSlf4j())
+      Level.DEBUG -> underlyingLogger.isDebugEnabled(marker?.toSlf4j())
+      Level.INFO -> underlyingLogger.isInfoEnabled(marker?.toSlf4j())
+      Level.WARN -> underlyingLogger.isWarnEnabled(marker?.toSlf4j())
+      Level.ERROR -> underlyingLogger.isErrorEnabled(marker?.toSlf4j())
+      Level.OFF -> false
+    }
+  }
+}

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
@@ -8,6 +8,10 @@ import org.slf4j.Logger
 
 public abstract class Slf4jLogger : KLogger {
 
+  // we don't move more methods to here because if it will appear on stacktrace
+  // it will break fqcn for class name in location aware loggers
+  // (tests are also failing when doing this)
+
   protected fun isLoggingEnabledFor(
     underlyingLogger: Logger,
     level: Level,

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/slf4j/internal/Slf4jLogger.kt
@@ -1,54 +1,18 @@
 package io.github.oshai.kotlinlogging.slf4j.internal
 
-import io.github.oshai.kotlinlogging.DelegatingKLogger
 import io.github.oshai.kotlinlogging.KLogger
-import io.github.oshai.kotlinlogging.KLoggingEventBuilder
 import io.github.oshai.kotlinlogging.Level
 import io.github.oshai.kotlinlogging.Marker
 import io.github.oshai.kotlinlogging.slf4j.toSlf4j
 import org.slf4j.Logger
-import org.slf4j.spi.CallerBoundaryAware
 
-public abstract class Slf4jLogger<T : Logger> : KLogger, DelegatingKLogger<T> {
+public abstract class Slf4jLogger : KLogger {
 
-  override val name: String
-    get() = underlyingLogger.name
-
-  protected abstract val fqcn: String?
-  override fun at(level: Level, marker: Marker?, block: KLoggingEventBuilder.() -> Unit) {
-    if (isLoggingEnabledFor(level, marker)) {
-      KLoggingEventBuilder().apply(block).run {
-        if (payload != null) {
-          logWithPayload(this, level, marker)
-        } else {
-          logWithoutPayload(this, level, marker)
-        }
-      }
-    }
-  }
-
-  protected abstract fun logWithoutPayload(
-    kLoggingEventBuilder: KLoggingEventBuilder,
+  protected fun isLoggingEnabledFor(
+    underlyingLogger: Logger,
     level: Level,
     marker: Marker?
-  )
-
-  private fun logWithPayload(
-    kLoggingEventBuilder: KLoggingEventBuilder,
-    level: Level,
-    marker: Marker?
-  ) {
-    val builder = underlyingLogger.atLevel(level.toSlf4j())
-    marker?.toSlf4j()?.let { builder.addMarker(it) }
-    kLoggingEventBuilder.payload?.forEach { (key, value) -> builder.addKeyValue(key, value) }
-    builder.setCause(kLoggingEventBuilder.cause)
-    if (builder is CallerBoundaryAware) {
-      builder.setCallerBoundary(fqcn)
-    }
-    builder.log(kLoggingEventBuilder.message)
-  }
-
-  override fun isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
+  ): Boolean {
     return when (level) {
       Level.TRACE -> underlyingLogger.isTraceEnabled(marker?.toSlf4j())
       Level.DEBUG -> underlyingLogger.isDebugEnabled(marker?.toSlf4j())


### PR DESCRIPTION
This allows to be more backward compatible for version that doesn't support fluent logging / payload etc'