### PR TITLE
Add workflow to publish Dokka HTML docs to project site

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -73,6 +73,8 @@ jobs:
           destination: ${{ env.JEKYLL_OUTPUT_DIR }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
+        with:
+          path: ${{ env.JEKYLL_OUTPUT_DIR }}
 
   # Deployment job
   deploy:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   api-docs:
     name: Generate Dokka HTML docs
-    runs-on: ubuntu-latest
+    runs-on: macos-latest # For Kotlin/Native
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -47,6 +47,7 @@ jobs:
           if-no-files-found: error
   # Build job
   build:
+    name: Build Jekyll docs
     runs-on: ubuntu-latest
     needs: api-docs
     steps:
@@ -69,6 +70,7 @@ jobs:
 
   # Deployment job
   deploy:
+    name: Deploy to GitHub Pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -52,18 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: api-docs
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       # Workaround for https://github.com/actions/jekyll-build-pages/issues/101
       - name: Create output directory
         run: mkdir ${{ env.JEKYLL_OUTPUT_DIR }}
-      # We need to run this before the Jekyll site is built, otherwise we get
-      # a permission denied error - see https://github.com/actions/jekyll-build-pages/issues/101
-      - name: Download Dokka artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.DOKKA_ARTIFACT_NAME }}
-          path: ${{ env.JEKYLL_OUTPUT_DIR }}/api
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build with Jekyll
@@ -71,6 +62,11 @@ jobs:
         with:
           source: ./
           destination: ${{ env.JEKYLL_OUTPUT_DIR }}
+      - name: Download Dokka artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DOKKA_ARTIFACT_NAME }}
+          path: ${{ env.JEKYLL_OUTPUT_DIR }}/api
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,79 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  DOKKA_ARTIFACT_NAME: dokka-html 
+
+jobs:
+  api-docs:
+    name: Generate Dokka HTML docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Generate Dokka HTML docs
+        run: ./gradlew :dokkaHtml
+      - name: Upload Dokka output
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DOKKA_ARTIFACT_NAME }}
+          path: build/dokka/html
+          if-no-files-found: error
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    needs: api-docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Download Dokka artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DOKKA_ARTIFACT_NAME }}
+          path: ./_site/api
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,6 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  JEKYLL_OUTPUT_DIR: ./dist
   DOKKA_ARTIFACT_NAME: dokka-html 
 
 jobs:
@@ -53,18 +54,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # Workaround for https://github.com/actions/jekyll-build-pages/issues/101
+      - name: Create output directory
+        run: mkdir ${{ env.JEKYLL_OUTPUT_DIR }}
+      # We need to run this before the Jekyll site is built, otherwise we get
+      # a permission denied error - see https://github.com/actions/jekyll-build-pages/issues/101
+      - name: Download Dokka artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DOKKA_ARTIFACT_NAME }}
+          path: ${{ env.JEKYLL_OUTPUT_DIR }}/api
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
-          destination: ./_site
-      - name: Download Dokka artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.DOKKA_ARTIFACT_NAME }}
-          path: ./_site/api
+          destination: ${{ env.JEKYLL_OUTPUT_DIR }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,8 @@ name: Deploy to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    # TODO: Remove
+    #branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,8 +4,7 @@ name: Deploy to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    # TODO: Remove
-    #branches: ["master"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Fixes #382

Demo: https://edricchan03.github.io/kotlin-logging/api/ ([workflow run](https://github.com/EdricChan03/kotlin-logging/actions/runs/7302473812))

Note: You'll have to change the GitHub Pages source to use GitHub Actions instead, see the [help docs on configuring a publishing source](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) for more info

I've also noticed that there's a really old "docs" folder that doesn't seem to be used - should this be removed as well?

(Also, let me know if I should squash the 8 commits together on my end)