### PR TITLE
Fluent Logging: Allow nullable values

### DIFF
--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEventBuilder.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEventBuilder.kt
@@ -3,5 +3,5 @@ package io.github.oshai.kotlinlogging
 public class KLoggingEventBuilder {
   public var message: String? = null
   public var cause: Throwable? = null
-  public var payload: Map<String, Any>? = null
+  public var payload: Map<String, Any?>? = null
 }

--- a/src/directMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEvent.kt
+++ b/src/directMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEvent.kt
@@ -6,7 +6,7 @@ public data class KLoggingEvent(
   public val loggerName: String,
   public val message: String? = null,
   public val cause: Throwable? = null,
-  public val payload: Map<String, Any>? = null,
+  public val payload: Map<String, Any?>? = null,
 ) {
   public constructor(
     level: Level,


### PR DESCRIPTION
References: https://github.com/oshai/kotlin-logging/issues/400#issuecomment-1964617668

Example:
```kotlin
Example:

logger.atError {
    this.message = "Failed to make a good example: ${throwable.message}."
    this.cause = throwable
    this.payload = mapOf(
        "itemOne" to headers.getNullableThing(),
    )
}
```

Allows the value in the payload to be nullable. It seems that the code referencing the payloads are are written in Java so it is harder to know if this will lead to a null pointer exception or other troubles with possible loggers but the tests pass.