### PR TITLE
allow only markers being supplied

### DIFF
--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLogger.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLogger.kt
@@ -74,35 +74,35 @@ public interface KLogger {
     }
 
   /** Lazy add a log message if isTraceEnabled is true */
-  public fun trace(throwable: Throwable?, marker: Marker?, message: () -> Any?): Unit =
+  public fun trace(throwable: Throwable? = null, marker: Marker?, message: () -> Any?): Unit =
     at(Level.TRACE, marker) {
       this.message = message.toStringSafe()
       this.cause = throwable
     }
 
   /** Lazy add a log message if isDebugEnabled is true */
-  public fun debug(throwable: Throwable?, marker: Marker?, message: () -> Any?): Unit =
+  public fun debug(throwable: Throwable? = null, marker: Marker?, message: () -> Any?): Unit =
     at(Level.DEBUG, marker) {
       this.message = message.toStringSafe()
       this.cause = throwable
     }
 
   /** Lazy add a log message if isInfoEnabled is true */
-  public fun info(throwable: Throwable?, marker: Marker?, message: () -> Any?): Unit =
+  public fun info(throwable: Throwable? = null, marker: Marker?, message: () -> Any?): Unit =
     at(Level.INFO, marker) {
       this.message = message.toStringSafe()
       this.cause = throwable
     }
 
   /** Lazy add a log message if isWarnEnabled is true */
-  public fun warn(throwable: Throwable?, marker: Marker?, message: () -> Any?): Unit =
+  public fun warn(throwable: Throwable? = null, marker: Marker?, message: () -> Any?): Unit =
     at(Level.WARN, marker) {
       this.message = message.toStringSafe()
       this.cause = throwable
     }
 
   /** Lazy add a log message if isErrorEnabled is true */
-  public fun error(throwable: Throwable?, marker: Marker?, message: () -> Any?): Unit =
+  public fun error(throwable: Throwable? = null, marker: Marker?, message: () -> Any?): Unit =
     at(Level.ERROR, marker) {
       this.message = message.toStringSafe()
       this.cause = throwable

--- a/src/commonTest/kotlin/io/github/oshai/kotlinlogging/SimpleTest.kt
+++ b/src/commonTest/kotlin/io/github/oshai/kotlinlogging/SimpleTest.kt
@@ -9,4 +9,16 @@ class SimpleTest {
   fun simpleTest() {
     logger.info { "Hello!" }
   }
+
+  @Test
+  fun shouldSupportMarkers() {
+
+    val marker = KMarkerFactory.getMarker("someMarker")
+
+    logger.info(marker = marker) { "info" }
+    logger.debug(marker = marker) { "debug" }
+    logger.error(marker = marker) { "error" }
+    logger.error(marker = marker) { "warn" }
+    logger.trace(marker = marker) { "trace" }
+  }
 }


### PR DESCRIPTION
I think the api could be improved a bit by not requiring the throwable, which could result in the following:
```
logger.info(marker=myMarker) { "some Message" }
```
Especially you do not need to supply a throwable when logging info in this case.
Due to the deprecation of the previous methods the test still uses deprecated methods. 
If the old methods are removed, the problem wont occur anymore.