### PR TITLE
Upgrading Gradle to 8.X

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text eol=lf
+*.bat eol=crlf
+*.png binary
+*.jar binary

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Publish
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -no-daemon --no-parallel --stacktrace -DSONATYPE_USERNAME_2=$SONATYPE_USERNAME_2 -DSONATYPE_PASSWORD_2=$SONATYPE_PASSWORD_2 -DGPG_PRIVATE_PASSWORD=$GPG_PRIVATE_PASSWORD -DGPG_PRIVATE_KEY=$GPG_PRIVATE_KEY
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Restore Gradle cache
         id: cache-gradle

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Generate Dokka HTML docs
         run: ./gradlew :dokkaHtml
       - name: Upload Dokka output

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,16 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform") version "1.9.23"
-    id("com.android.library") version "7.4.2"
+    // This version is dependent on the maximum tested version
+    // of this plugin within the Kotlin multiplatform library
+    id("com.android.library") version "8.2.2"
 
     id("org.jetbrains.dokka") version "1.9.20"
 
@@ -28,6 +32,9 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = JvmTarget.JVM_1_8.target
+}
 
 kotlin {
     explicitApi()
@@ -69,7 +76,7 @@ kotlin {
             }
         }
     }
-    android {
+    androidTarget {
         publishLibraryVariants("release", "debug")
     }
     val linuxTargets = listOf(
@@ -206,8 +213,8 @@ android {
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 21
-        targetSdk = 31
     }
+    @Suppress("UnstableApiUsage")
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
-distributionSha256Sum=518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionSha256Sum=194717442575a6f96e1c1befa2c30e9a4fc90f701d7aee33eb879b79e7ff05c0
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/commonTest/kotlin/io/github/oshai/kotlinlogging/SimpleTest.kt
+++ b/src/commonTest/kotlin/io/github/oshai/kotlinlogging/SimpleTest.kt
@@ -2,6 +2,7 @@ package io.github.oshai.kotlinlogging
 
 import kotlin.test.Test
 
+@Suppress("DEPRECATION")
 class SimpleTest {
   private val logger = KotlinLogging.logger {}
 

--- a/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
+++ b/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.*
 
 private val logger = KotlinLogging.logger("SimpleJsTest")
 
+@Suppress("DEPRECATION")
 class SimpleJsTest {
   private lateinit var appender: SimpleAppender
 

--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,5 +1,5 @@
 extra["slf4j_version"] = "2.0.9"
-extra["coroutines_version"] = "1.6.4"
+extra["coroutines_version"] = "1.8.0"
 extra["log4j_version"] = "2.22.0"
 extra["mockito_version"] = "4.11.0"
 extra["junit_version"] = "5.9.2"


### PR DESCRIPTION
Upgraded Gradle to 8.7; Upgraded Android plugin to 8.2.2; Upgraded Kotlin Coroutines version to 1.8.0; Enabled cross-platform compatibility for Spotless plugin; Silencing some compiler warnings

Fixes #288 