### PR TITLE
Leverage tail recursion when creating message out of Throwable

### DIFF
--- a/src/directMain/kotlin/io/github/oshai/kotlinlogging/Formatter.kt
+++ b/src/directMain/kotlin/io/github/oshai/kotlinlogging/Formatter.kt
@@ -29,16 +29,13 @@ public class DefaultMessageFormatter(private val includePrefix: Boolean = true) 
     }
   }
 
-  private fun Throwable?.throwableToString(): String {
-    if (this == null) {
-      return ""
+  private fun Throwable?.throwableToString() = createThrowableMsg("", this)
+
+  private tailrec fun createThrowableMsg(msg: String, throwable: Throwable?): String {
+    return if (throwable == null || throwable.cause == throwable) {
+      msg
+    } else {
+      createThrowableMsg("$msg, Caused by: '${throwable.message}'", throwable.cause)
     }
-    var msg = ""
-    var current = this
-    while (current != null && current.cause != current) {
-      msg += ", Caused by: '${current.message}'"
-      current = current.cause
-    }
-    return msg
   }
 }

--- a/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
+++ b/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
@@ -35,7 +35,10 @@ class SimpleJsTest {
     val innerMessage = "Inner Message"
     val throwable = Throwable(message = outerMessage, cause = Throwable(message = innerMessage))
     logger.error(throwable) { errorLog }
-    assertEquals("ERROR: [SimpleJsTest] $errorLog, Caused by: '$outerMessage', Caused by: '$innerMessage'", appender.lastMessage)
+    assertEquals(
+      "ERROR: [SimpleJsTest] $errorLog, Caused by: '$outerMessage', Caused by: '$innerMessage'",
+      appender.lastMessage,
+    )
   }
 
   @Test

--- a/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
+++ b/src/jsTest/kotlin/io/github/oshai/kotlinlogging/SimpleJsTest.kt
@@ -29,6 +29,16 @@ class SimpleJsTest {
   }
 
   @Test
+  fun logThrowableTest() {
+    val errorLog = "Something Bad Happened"
+    val outerMessage = "Outer Message"
+    val innerMessage = "Inner Message"
+    val throwable = Throwable(message = outerMessage, cause = Throwable(message = innerMessage))
+    logger.error(throwable) { errorLog }
+    assertEquals("ERROR: [SimpleJsTest] $errorLog, Caused by: '$outerMessage', Caused by: '$innerMessage'", appender.lastMessage)
+  }
+
+  @Test
   fun offLevelJsTest() {
     KotlinLoggingConfiguration.LOG_LEVEL = Level.OFF
     assertTrue(logger.isLoggingOff())


### PR DESCRIPTION
This simplifies the code a bit and will allow tailrec optimization in native builds