### PR TITLE
feat: add wasmWasi target with console appender and tests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,10 @@ Below is a list of all versions, some history and note-worthy changes.
 
 # Version 7
 
+Unreleased changes (will be part of next 7.x release):
+
+- Add WebAssembly WASI (wasmWasi) target relying on directMain console output.
+
 Released on: Jun 14, 2024.  
 Full change log:
 [v.7](https://github.com/oshai/kotlin-logging/releases/tag/7.0.0).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,11 @@ kotlin {
             }
         }
     }
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmWasi { // console based WASI target
+        // Use nodejs as runtime env for tests & distribution (WASI support via node --experimental-wasi-unstable-preview1)
+        nodejs()
+    }
     androidTarget {
         publishLibraryVariants("release", "debug")
     }
@@ -216,6 +221,14 @@ kotlin {
         val wasmJsTest by getting {
             dependencies {
                 implementation(kotlin("test-wasm-js"))
+            }
+        }
+        val wasmWasiMain by getting {
+            dependsOn(directMain)
+        }
+        val wasmWasiTest by getting {
+            dependencies {
+                implementation(kotlin("test-wasm-wasi"))
             }
         }
         val nativeMain by creating {

--- a/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/ConsoleOutputAppender.kt
+++ b/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/ConsoleOutputAppender.kt
@@ -1,0 +1,11 @@
+package io.github.oshai.kotlinlogging
+
+// Simple console appender for WASI target relying on stdout
+public object ConsoleOutputAppender : FormattingAppender() {
+  override fun logFormattedMessage(loggingEvent: KLoggingEvent, formattedMessage: Any?) {
+    when (loggingEvent.level) {
+      Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR -> println(formattedMessage)
+      Level.OFF -> Unit
+    }
+  }
+}

--- a/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,0 +1,7 @@
+package io.github.oshai.kotlinlogging
+
+public actual object KotlinLoggingConfiguration {
+  public actual var logLevel: Level = Level.INFO
+  public actual var formatter: Formatter = DefaultMessageFormatter(includePrefix = true)
+  public actual var appender: Appender = ConsoleOutputAppender
+}

--- a/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggerNameResolver.kt
+++ b/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggerNameResolver.kt
@@ -1,0 +1,25 @@
+package io.github.oshai.kotlinlogging.internal
+
+private const val NO_CLASS = ""
+
+internal actual object KLoggerNameResolver {
+  private val kotlinLoggingRegex = Regex("\\.KotlinLogging\\.logger\\s")
+  private val topLevelPropertyRegex = Regex("<init properties (\\S+)\\.kt>")
+  private val classPropertyRegex = Regex("\\.(\\S+)\\.<init>")
+
+  internal actual fun name(func: () -> Unit): String {
+    val stackTrace = Exception().stackTraceToString().split("\n")
+    val invokingClassLine = stackTrace.indexOfFirst(kotlinLoggingRegex::containsMatchIn) + 1
+    return if (invokingClassLine in 1 ..< stackTrace.size) {
+      getInvokingClass(stackTrace[invokingClassLine])
+    } else {
+      NO_CLASS
+    }
+  }
+
+  private fun getInvokingClass(line: String): String {
+    return topLevelPropertyRegex.find(line)?.let { it.groupValues[1].split(".").last() }
+      ?: classPropertyRegex.find(line)?.let { it.groupValues[1].split(".").last() }
+      ?: NO_CLASS
+  }
+}

--- a/src/wasmWasiTest/kotlin/io/github/oshai/kotlinlogging/SimpleWasmWasiTest.kt
+++ b/src/wasmWasiTest/kotlin/io/github/oshai/kotlinlogging/SimpleWasmWasiTest.kt
@@ -1,0 +1,66 @@
+package io.github.oshai.kotlinlogging
+
+import kotlin.test.*
+
+private val namedLogger = KotlinLogging.logger("SimpleWasmWasiTest")
+private val anonymousFilePropLogger = KotlinLogging.logger {}
+
+class SimpleWasmWasiTest {
+  private lateinit var appender: SimpleAppender
+  private val anonymousClassPropLogger = KotlinLogging.logger {}
+
+  @BeforeTest
+  fun setup() {
+    appender = createAppender()
+    KotlinLoggingConfiguration.appender = appender
+  }
+
+  @AfterTest
+  fun cleanup() {
+    KotlinLoggingConfiguration.appender = ConsoleOutputAppender
+    KotlinLoggingConfiguration.logLevel = Level.INFO
+  }
+
+  @Test
+  fun simpleWasiTest() {
+    assertEquals("SimpleWasmWasiTest", namedLogger.name)
+    namedLogger.info { "info msg" }
+    assertEquals("INFO: [SimpleWasmWasiTest] info msg", appender.lastMessage)
+    assertEquals("info", appender.lastLevel)
+  }
+
+  @Test
+  fun anonymousFilePropWasiTest() {
+    assertEquals("SimpleWasmWasiTest", anonymousFilePropLogger.name)
+    anonymousFilePropLogger.info { "info msg" }
+    assertEquals("INFO: [SimpleWasmWasiTest] info msg", appender.lastMessage)
+  }
+
+  @Test
+  fun anonymousClassPropWasiTest() {
+    assertEquals("SimpleWasmWasiTest", anonymousClassPropLogger.name)
+    anonymousClassPropLogger.info { "info msg" }
+    assertEquals("INFO: [SimpleWasmWasiTest] info msg", appender.lastMessage)
+  }
+
+  @Test
+  fun offLevelWasiTest() {
+    KotlinLoggingConfiguration.logLevel = Level.OFF
+    assertTrue(namedLogger.isLoggingOff())
+    namedLogger.error { "error msg" }
+    assertEquals("NA", appender.lastMessage)
+    assertEquals("NA", appender.lastLevel)
+  }
+
+  private fun createAppender(): SimpleAppender = SimpleAppender()
+
+  class SimpleAppender : Appender {
+    var lastMessage: String = "NA"
+    var lastLevel: String = "NA"
+
+    override fun log(loggingEvent: KLoggingEvent) {
+      lastMessage = DefaultMessageFormatter(includePrefix = true).formatMessage(loggingEvent)
+      lastLevel = loggingEvent.level.name.lowercase()
+    }
+  }
+}


### PR DESCRIPTION
Summary Adds WebAssembly WASI (wasmWasi) target to kotlin-logging, reusing directMain logic and providing a simple console appender.

Motivation Enable kotlin-logging usage in WASI runtimes (e.g. wasmtime, Node.js WASI, future serverless/Wasm hosts) with minimal setup, consistent with existing wasmJs and native behavior.

Key Changes

Gradle: added wasmWasi target (with nodejs() environment) + source sets (wasmWasiMain / wasmWasiTest).
New actuals for wasmWasi:
KotlinLoggingConfiguration (simple mutable properties)
ConsoleOutputAppender (stdout println for all levels except OFF)
KLoggerNameResolver (mirrors wasmJs stacktrace-based resolver)
Tests: SimpleWasmWasiTest (basic logging + OFF level check)
Changelog: unreleased note about wasmWasi support.

Design Notes

Uses println (no stderr separation; WASI stderr mapping can be added later if needed).
Reuses directMain API surface; no public API changes.
Keeps implementation minimal to reduce maintenance burden.
Node.js runtime declared to satisfy current Gradle/WASM DSL expectations.
Testing

Compiled wasmWasi main & tests (compileKotlinWasmWasi / compileTestKotlinWasmWasi succeeded).
Did not run full build due to missing Android SDK in current environment (pre-existing constraint).
Logic mirrors existing wasmJs test patterns minus JS console interception.
Backward Compatibility

No breaking changes; new target only.
Existing platforms unaffected.